### PR TITLE
feat: migrate to `tree-sitter.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,5 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.20.8"
-  },
-  "tree-sitter": [
-    {
-      "scope": "source.ocamllex",
-      "file-types": [
-        "mll"
-      ],
-      "injection-regex": "^(mll|ocamllex)$"
-    }
-  ]
+  }
 }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,35 @@
+{
+  "grammars": [
+    {
+      "name": "ocamllex",
+      "camelcase": "Ocamllex",
+      "scope": "source.ocamllex",
+      "path": ".",
+      "file-types": [
+        "mll"
+      ],
+      "injection-regex": "^(mll|ocamllex)$"
+    }
+  ],
+  "metadata": {
+    "version": "0.20.2",
+    "license": "MIT",
+    "description": "OCamllex grammar for tree-sitter",
+    "authors": [
+      {
+        "name": "Pieter Goetschalckx"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/314eter/tree-sitter-ocamllex"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Hey, putting up this PR because this file will be a requirement in 0.25, and this is one of the few remaining grammars out there that hasn't migrated.